### PR TITLE
Convert the `LinkedList` record to Object

### DIFF
--- a/cache-ballerina/Ballerina.toml
+++ b/cache-ballerina/Ballerina.toml
@@ -1,23 +1,23 @@
 [project]
 org-name = "ballerina"
-version = "2.0.0"
+version = "@toml.version@"
 
 [dependencies]
-"ballerina/task" = "1.1.0"
-"ballerina/log" = "1.0.0"
-"ballerina/time" = "1.0.1"
-"ballerina/runtime" = "0.5.0"
-"ballerina/io" = "0.5.0"
-"ballerina/system" = "0.6.0"
-"ballerina/stringutils" = "0.5.0"
-"ballerina/config" = "1.0.0"
+"ballerina/task" = "@stdlib.task.version@"
+"ballerina/log" = "@stdlib.log.version@"
+"ballerina/time" = "@stdlib.time.version@"
+"ballerina/io" = "@stdlib.io.version@"
+"ballerina/stringutils" = "@stdlib.stringutils.version@"
+"ballerina/config" = "@stdlib.config.version@"
+"ballerina/system" = "@stdlib.system.version@"
+"ballerina/runtime" = "@stdlib.runtime.version@"
 
 [platform]
 target = "java8"
 
     [[platform.libraries]]
     artifactId = "cache"
-    version = "2.0.0-SNAPSHOT"
-    path = "../cache-native/build/libs/cache-native-2.0.0-SNAPSHOT.jar"
+    version = "@project.version@"
+    path = "../cache-native/build/libs/cache-native-@project.version@.jar"
     groupId = "ballerina"
     modules = ["cache"]

--- a/cache-ballerina/Ballerina.toml
+++ b/cache-ballerina/Ballerina.toml
@@ -1,23 +1,23 @@
 [project]
 org-name = "ballerina"
-version = "@toml.version@"
+version = "2.0.0"
 
 [dependencies]
-"ballerina/task" = "@stdlib.task.version@"
-"ballerina/log" = "@stdlib.log.version@"
-"ballerina/time" = "@stdlib.time.version@"
-"ballerina/runtime" = "@stdlib.runtime.version@"
-"ballerina/io" = "@stdlib.io.version@"
-"ballerina/system" = "@stdlib.system.version@"
-"ballerina/stringutils" = "@stdlib.stringutils.version@"
-"ballerina/config" = "@stdlib.config.version@"
+"ballerina/task" = "1.1.0"
+"ballerina/log" = "1.0.0"
+"ballerina/time" = "1.0.1"
+"ballerina/runtime" = "0.5.0"
+"ballerina/io" = "0.5.0"
+"ballerina/system" = "0.6.0"
+"ballerina/stringutils" = "0.5.0"
+"ballerina/config" = "1.0.0"
 
 [platform]
 target = "java8"
 
     [[platform.libraries]]
     artifactId = "cache"
-    version = "@project.version@"
-    path = "../cache-native/build/libs/cache-native-@project.version@.jar"
+    version = "2.0.0-SNAPSHOT"
+    path = "../cache-native/build/libs/cache-native-2.0.0-SNAPSHOT.jar"
     groupId = "ballerina"
     modules = ["cache"]

--- a/cache-ballerina/src/cache/abstract_eviction_policy.bal
+++ b/cache-ballerina/src/cache/abstract_eviction_policy.bal
@@ -20,38 +20,31 @@ public type AbstractEvictionPolicy object {
 
     # Updates the linked list based on the get operation.
     #
-    # + list - Linked list data structure, which is used to govern the eviction policy
     # + node - Node of the linked list, which is retrieved
-    public isolated function get(LinkedList list, Node node);
+    public isolated function get(Node node);
 
     # Updates the linked list based on the put operation.
     #
-    # + list - Linked list data structure, which is used to govern the eviction policy
     # + node - Node of the linked list, which is added newly
-    public isolated function put(LinkedList list, Node node);
+    public isolated function put(Node node);
 
     # Updates the linked list based on the remove operation.
     #
-    # + list - Linked list data structure, which is used to govern the eviction policy
     # + node - Node of the linked list, which is deleted
-    public isolated function remove(LinkedList list, Node node);
+    public isolated function remove(Node node);
 
     # Updates the linked list based on the replace operation.
     #
-    # + list - Linked list data structure, which is used to govern the eviction policy
     # + newNode - Node of the linked list, which will be replacing the `oldNode`
     # + oldNode - Node of the linked list, which will be replaced by the `newNode`
-    public isolated function replace(LinkedList list, Node newNode, Node oldNode);
+    public isolated function replace(Node newNode, Node oldNode);
 
     # Updates the linked list based on the clear operation.
-    #
-    # + list - Linked list data structure, which is used to govern the eviction policy
-    public isolated function clear(LinkedList list);
+    public isolated function clear();
 
     # Updates the linked list based on the evict operation.
     #
-    # + list - Linked list data structure, which is used to govern the eviction policy
     # + return - The Node, which is evicted from the linked list or `()` if nothing to be evicted
-    public isolated function evict(LinkedList list) returns Node?;
+    public isolated function evict() returns Node?;
 
 };

--- a/cache-ballerina/src/cache/cache.bal
+++ b/cache-ballerina/src/cache/cache.bal
@@ -46,11 +46,11 @@ boolean cleanupInProgress = false;
 
 // Cleanup service which cleans the cache entries periodically.
 final service cleanupService = service {
-    resource function onTrigger(Cache cache, LinkedList list, AbstractEvictionPolicy evictionPolicy) {
+    resource function onTrigger(Cache cache, AbstractEvictionPolicy evictionPolicy) {
         // This check will skip the processes triggered while the clean up in progress.
         if (!cleanupInProgress) {
             cleanupInProgress = true;
-            cleanup(cache, list, evictionPolicy);
+            cleanup(cache, evictionPolicy);
             cleanupInProgress = false;
         }
     }
@@ -66,7 +66,6 @@ public class Cache {
     private AbstractEvictionPolicy evictionPolicy;
     private float evictionFactor;
     private int defaultMaxAgeInSeconds;
-    private LinkedList list;
 
     # Called when a new `cache:Cache` object is created.
     #
@@ -91,11 +90,6 @@ public class Cache {
             panic prepareError("Default max age should be greater than 0 or -1 for indicate forever valid.");
         }
 
-        self.list = {
-            head: (),
-            tail: ()
-        };
-
         externInit(self, self.capacity);
 
         int? cleanupIntervalInSeconds = cacheConfig?.cleanupIntervalInSeconds;
@@ -105,7 +99,7 @@ public class Cache {
                 initialDelayInMillis: cleanupIntervalInSeconds
             };
             task:Scheduler cleanupScheduler = new(timerConfiguration);
-            task:SchedulerError? result = cleanupScheduler.attach(cleanupService, self, self.list, self.evictionPolicy);
+            task:SchedulerError? result = cleanupScheduler.attach(cleanupService, self, self.evictionPolicy);
             if (result is task:SchedulerError) {
                 panic prepareError("Failed to create the cache cleanup task.", result);
             }
@@ -131,7 +125,7 @@ public class Cache {
         }
         // If the current cache is full (i.e. size = capacity), evict cache.
         if (self.size() == self.capacity) {
-            evict(self, self.list, self.evictionPolicy, self.capacity, self.evictionFactor);
+            evict(self, self.evictionPolicy, self.capacity, self.evictionFactor);
         }
 
         // Calculate the `expTime` of the cache entry based on the `maxAgeInSeconds` property and
@@ -154,9 +148,9 @@ public class Cache {
 
         if (self.hasKey(key)) {
             Node oldNode = externGet(self, key);
-            self.evictionPolicy.replace(self.list, newNode, oldNode);
+            self.evictionPolicy.replace(newNode, oldNode);
         } else {
-            self.evictionPolicy.put(self.list, newNode);
+            self.evictionPolicy.put(newNode);
         }
         externPut(self, key, newNode);
     }
@@ -179,12 +173,12 @@ public class Cache {
         // and runs in predefined intervals, sometimes the cache entry might not have been removed at this point
         // even though it is expired. So this check guarantees that the expired cache entries will not be returned.
         if (entry.expTime != -1 && entry.expTime < time:nanoTime()) {
-            self.evictionPolicy.remove(self.list, node);
+            self.evictionPolicy.remove(node);
             externRemove(self, key);
             return ();
         }
 
-        self.evictionPolicy.get(self.list, node);
+        self.evictionPolicy.get(node);
         return entry.data;
     }
 
@@ -200,7 +194,7 @@ public class Cache {
         }
 
         Node node = externGet(self, key);
-        self.evictionPolicy.remove(self.list, node);
+        self.evictionPolicy.remove(node);
         externRemove(self, key);
     }
 
@@ -209,7 +203,7 @@ public class Cache {
     # + return - `()` if successfully discarded all the values from the cache or an `Error` if any error occurred while
     # discarding all the values from the cache.
     public isolated function invalidateAll() returns Error? {
-        self.evictionPolicy.clear(self.list);
+        self.evictionPolicy.clear();
         externRemoveAll(self);
     }
 
@@ -244,10 +238,10 @@ public class Cache {
     }
 }
 
-isolated function evict(Cache cache, LinkedList list, AbstractEvictionPolicy evictionPolicy, int capacity, float evictionFactor) {
+isolated function evict(Cache cache, AbstractEvictionPolicy evictionPolicy, int capacity, float evictionFactor) {
     int evictionKeysCount = <int>(capacity * evictionFactor);
     foreach int i in 1...evictionKeysCount {
-        Node? node = evictionPolicy.evict(list);
+        Node? node = evictionPolicy.evict();
         if (node is Node) {
             CacheEntry entry = <CacheEntry>node.value;
             externRemove(cache, entry.key);
@@ -259,7 +253,7 @@ isolated function evict(Cache cache, LinkedList list, AbstractEvictionPolicy evi
     }
 }
 
-isolated function cleanup(Cache cache, LinkedList list, AbstractEvictionPolicy evictionPolicy) {
+isolated function cleanup(Cache cache, AbstractEvictionPolicy evictionPolicy) {
     if (externSize(cache) == 0) {
         return;
     }
@@ -267,7 +261,7 @@ isolated function cleanup(Cache cache, LinkedList list, AbstractEvictionPolicy e
         Node node = externGet(cache, key);
         CacheEntry entry = <CacheEntry>node.value;
         if (entry.expTime != -1 && entry.expTime < time:nanoTime()) {
-            evictionPolicy.remove(list, node);
+            evictionPolicy.remove(node);
             externRemove(cache, entry.key);
             // The return result (error which occurred due to unavailability of the key or nil) is ignored
             // since no purpose of handling it.

--- a/cache-ballerina/src/cache/linked_list.bal
+++ b/cache-ballerina/src/cache/linked_list.bal
@@ -27,75 +27,68 @@ public type Node record {|
     Node? next = ();
 |};
 
-# Represents a linked list, which is used to govern the cache eviction policy.
+# The `cache:LruLinkedList` object consists operations of `LinkedList` data structure which are related
+# to LRU eviction algorithm
 #
 # + head - The first node of the linked list
 # + tail - The last node of the linked list
-public type LinkedList record {
-    Node? head;
-    Node? tail;
-};
-
-# The `cache:LruLinkedList` object consists operations of `LinkedList` data structure which are related
-# to LRU eviction algorithm
-public class LruLinkedList {
+public class LinkedList {
 
     // This flag is used to avoid concurrency issues occurring during the removing nodes from the linked-list.
     // Ballerina locks cannot be used for this since it may lead to unexpected results.
     boolean removeInProgress = false;
+    Node? head = ();
+    Node? tail = ();
 
     # Adds a node to the end of the provided linked list.
     #
-    # + list - Linked list to which the provided node should be added
     # + node - The node, which should be added to the provided linked list
-    public isolated function addLast(LinkedList list, Node node) {
-        if (list.tail is ()) {
-            list.head = node;
-            list.tail = list.head;
+    public isolated function addLast(Node node) {
+        if (self.tail is ()) {
+            self.head = node;
+            self.tail = self.head;
             return;
         }
 
-        Node tailNode = <Node>list.tail;
+        Node tailNode = <Node>self.tail;
         node.prev = tailNode;
         tailNode.next = node;
-        list.tail = node;
+        self.tail = node;
     }
 
     # Adds a node to the start of the provided linked list.
     #
-    # + list - Linked list to which the provided node should be added
     # + node - The node, which should be added to the provided linked list
-    public isolated function addFirst(LinkedList list, Node node) {
-        if (list.head is ()) {
-            list.head = node;
-            list.tail = list.head;
+    public isolated function addFirst(Node node) {
+        if (self.head is ()) {
+            self.head = node;
+            self.tail = self.head;
             return;
         }
 
-        Node headNode = <Node>list.head;
+        Node headNode = <Node>self.head;
         node.next = headNode;
         headNode.prev = node;
-        list.head = node;
+        self.head = node;
     }
 
     # Removes a node from the provided linked list.
     #
-    # + list - Linked list from which the provided node should be removed
     # + node - The node, which should be removed from the provided linked list
-    public isolated function remove(LinkedList list, Node node) {
-        // Using this flag, we prevent the concurrency issues, but this will avoid removing some nodes from the
-        // linked-list. Due to that, when the eviction happens, there can be situations where a node which is used
-        // recently is get removed from the cache.
+    public isolated function remove(Node node) {
+        // Using this flag, we prevent the concurrency issues, but this will avoid removing some nodes from the linked-list.
+        // Due to that, when the eviction happens, there can be situations where a node which is used recently is get
+        // removed from the cache.
         if (!self.removeInProgress) {
             self.removeInProgress = true;
             if (node.prev is ()) {
-                list.head = node.next;
+                self.head = node.next;
             } else {
                 Node prev = <Node>node.prev;
                 prev.next = node.next;
             }
             if (node.next is ()) {
-                list.tail = node.prev;
+                self.tail = node.prev;
             } else {
                 Node next = <Node>node.next;
                 next.prev = node.prev;
@@ -108,15 +101,14 @@ public class LruLinkedList {
 
     # Removes the last node from the provided linked list.
     #
-    # + list - Linked list from which the last node should be removed
     # + return - Last node of the provided linked list or `()` if the last node is empty
-    public isolated function removeLast(LinkedList list) returns Node? {
-        if (list.tail is ()) {
+    public isolated function removeLast() returns Node? {
+        if (self.tail is ()) {
             return ();
         }
-        Node tail = <Node>list.tail;
+        Node tail = <Node>self.tail;
         Node predecessorOfTail = <Node>tail.prev;
-        list.tail = predecessorOfTail;
+        self.tail = predecessorOfTail;
         predecessorOfTail.next = ();
         tail.prev = ();
 
@@ -124,10 +116,8 @@ public class LruLinkedList {
     }
 
     # Clears the provided linked list.
-    #
-    # + list - Linked list which should be cleared
-    public isolated function clear(LinkedList list) {
-        list.head = ();
-        list.tail = ();
+    public isolated function clear() {
+        self.head = ();
+        self.tail = ();
     }
 }

--- a/cache-ballerina/src/cache/linked_list.bal
+++ b/cache-ballerina/src/cache/linked_list.bal
@@ -49,11 +49,11 @@ public class LinkedList {
             self.tail = self.head;
             return;
         }
-
+        Node newNode = node;
         Node tailNode = <Node>self.tail;
-        node.prev = tailNode;
-        tailNode.next = node;
-        self.tail = node;
+        newNode.prev = tailNode;
+        tailNode.next = newNode;
+        self.tail = newNode;
     }
 
     # Adds a node to the start of the provided linked list.
@@ -65,11 +65,11 @@ public class LinkedList {
             self.tail = self.head;
             return;
         }
-
+        Node newNode = node;
         Node headNode = <Node>self.head;
-        node.next = headNode;
-        headNode.prev = node;
-        self.head = node;
+        newNode.next = headNode;
+        headNode.prev = newNode;
+        self.head = newNode;
     }
 
     # Removes a node from the provided linked list.

--- a/cache-ballerina/src/cache/linked_list.bal
+++ b/cache-ballerina/src/cache/linked_list.bal
@@ -49,11 +49,11 @@ public class LinkedList {
             self.tail = self.head;
             return;
         }
-        Node newNode = node;
+        Node tempNode = node;
         Node tailNode = <Node>self.tail;
-        newNode.prev = tailNode;
-        tailNode.next = newNode;
-        self.tail = newNode;
+        tempNode.prev = tailNode;
+        tailNode.next = tempNode;
+        self.tail = tempNode;
     }
 
     # Adds a node to the start of the provided linked list.
@@ -65,11 +65,11 @@ public class LinkedList {
             self.tail = self.head;
             return;
         }
-        Node newNode = node;
+        Node tempNode = node;
         Node headNode = <Node>self.head;
-        newNode.next = headNode;
-        headNode.prev = newNode;
-        self.head = newNode;
+        tempNode.next = headNode;
+        headNode.prev = tempNode;
+        self.head = tempNode;
     }
 
     # Removes a node from the provided linked list.

--- a/cache-ballerina/src/cache/linked_list.bal
+++ b/cache-ballerina/src/cache/linked_list.bal
@@ -27,7 +27,7 @@ public type Node record {|
     Node? next = ();
 |};
 
-# The `cache:LruLinkedList` object consists operations of `LinkedList` data structure which are related
+# The `cache:LinkedList` object consists operations of `LinkedList` data structure which are related
 # to LRU eviction algorithm
 #
 # + head - The first node of the linked list

--- a/cache-ballerina/src/cache/lru_eviction_policy.bal
+++ b/cache-ballerina/src/cache/lru_eviction_policy.bal
@@ -19,7 +19,12 @@
 public class LruEvictionPolicy {
 
     *AbstractEvictionPolicy;
-    LinkedList linkedList = new LinkedList();
+    LinkedList linkedList;
+
+    # Called when a new `cache:LruEvictionPolicy` object is created.
+    public isolated function init() {
+        self.linkedList = new LinkedList();
+    }
 
     # Updates the linked list based on the get operation related to the LRU eviction algorithm.
     #

--- a/cache-ballerina/src/cache/lru_eviction_policy.bal
+++ b/cache-ballerina/src/cache/lru_eviction_policy.bal
@@ -29,7 +29,7 @@ public class LruEvictionPolicy {
     # Updates the linked list based on the get operation related to the LRU eviction algorithm.
     #
     # + node - Node of the linked list, which is retrieved
-    public isolated function get(@tainted Node node) {
+    public isolated function get(Node node) {
         self.linkedList.remove(node);
         self.linkedList.addFirst(node);
     }
@@ -37,7 +37,7 @@ public class LruEvictionPolicy {
     # Updates the linked list based on the put operation related to the LRU eviction algorithm.
     #
     # + node - Node of the linked list, which is added newly
-    public isolated function put(@tainted Node node) {
+    public isolated function put(Node node) {
         self.linkedList.addFirst(node);
     }
 
@@ -52,7 +52,7 @@ public class LruEvictionPolicy {
     #
     # + newNode - Node of the linked list, which will be replacing the `oldNode`
     # + oldNode - Node of the linked list, which will be replaced by the `newNode`
-    public isolated function replace(@tainted Node newNode, Node oldNode) {
+    public isolated function replace(Node newNode, Node oldNode) {
         self.linkedList.remove(oldNode);
         self.linkedList.addFirst(newNode);
     }

--- a/cache-ballerina/src/cache/lru_eviction_policy.bal
+++ b/cache-ballerina/src/cache/lru_eviction_policy.bal
@@ -19,14 +19,15 @@
 public class LruEvictionPolicy {
 
     *AbstractEvictionPolicy;
+    private LruLinkedList linkedList = new LruLinkedList();
 
     # Updates the linked list based on the get operation related to the LRU eviction algorithm.
     #
     # + list - Linked list data structure, which is used to govern the eviction policy
     # + node - Node of the linked list, which is retrieved
     public isolated function get(LinkedList list, Node node) {
-        remove(list, node);
-        addFirst(list, node);
+        self.linkedList.remove(list, node);
+        self.linkedList.addFirst(list, node);
     }
 
     # Updates the linked list based on the put operation related to the LRU eviction algorithm.
@@ -34,7 +35,7 @@ public class LruEvictionPolicy {
     # + list - Linked list data structure, which is used to govern the eviction policy
     # + node - Node of the linked list, which is added newly
     public isolated function put(LinkedList list, Node node) {
-        addFirst(list, node);
+        self.linkedList.addFirst(list, node);
     }
 
     # Updates the linked list based on the remove operation related to the LRU eviction algorithm.
@@ -42,7 +43,7 @@ public class LruEvictionPolicy {
     # + list - Linked list data structure, which is used to govern the eviction policy
     # + node - Node of the linked list, which is deleted
     public isolated function remove(LinkedList list, Node node) {
-        remove(list, node);
+        self.linkedList.remove(list, node);
     }
 
     # Updates the linked list based on the replace operation related to the LRU eviction algorithm.
@@ -51,15 +52,15 @@ public class LruEvictionPolicy {
     # + newNode - Node of the linked list, which will be replacing the `oldNode`
     # + oldNode - Node of the linked list, which will be replaced by the `newNode`
     public isolated function replace(LinkedList list, Node newNode, Node oldNode) {
-        remove(list, oldNode);
-        addFirst(list, newNode);
+        self.linkedList.remove(list, oldNode);
+        self.linkedList.addFirst(list, newNode);
     }
 
     # Updates the linked list based on the clear operation related to the LRU eviction algorithm.
     #
     # + list - Linked list data structure, which is used to govern the eviction policy
     public isolated function clear(LinkedList list) {
-        clear(list);
+        self.linkedList.clear(list);
     }
 
     # Updates the linked list based on the evict operation.
@@ -67,7 +68,7 @@ public class LruEvictionPolicy {
     # + list - Linked list data structure, which is used to govern the eviction policy
     # + return - The Node, which is evicted from the linked list or `()` if nothing to be evicted
     public isolated function evict(LinkedList list) returns Node? {
-        return removeLast(list);
+        return self.linkedList.removeLast(list);
     }
 
 }

--- a/cache-ballerina/src/cache/lru_eviction_policy.bal
+++ b/cache-ballerina/src/cache/lru_eviction_policy.bal
@@ -19,56 +19,48 @@
 public class LruEvictionPolicy {
 
     *AbstractEvictionPolicy;
-    private LruLinkedList linkedList = new LruLinkedList();
+    LinkedList linkedList = new LinkedList();
 
     # Updates the linked list based on the get operation related to the LRU eviction algorithm.
     #
-    # + list - Linked list data structure, which is used to govern the eviction policy
     # + node - Node of the linked list, which is retrieved
-    public isolated function get(LinkedList list, Node node) {
-        self.linkedList.remove(list, node);
-        self.linkedList.addFirst(list, node);
+    public isolated function get(@tainted Node node) {
+        self.linkedList.remove(node);
+        self.linkedList.addFirst(node);
     }
 
     # Updates the linked list based on the put operation related to the LRU eviction algorithm.
     #
-    # + list - Linked list data structure, which is used to govern the eviction policy
     # + node - Node of the linked list, which is added newly
-    public isolated function put(LinkedList list, Node node) {
-        self.linkedList.addFirst(list, node);
+    public isolated function put(@tainted Node node) {
+        self.linkedList.addFirst(node);
     }
 
     # Updates the linked list based on the remove operation related to the LRU eviction algorithm.
     #
-    # + list - Linked list data structure, which is used to govern the eviction policy
     # + node - Node of the linked list, which is deleted
-    public isolated function remove(LinkedList list, Node node) {
-        self.linkedList.remove(list, node);
+    public isolated function remove(Node node) {
+        self.linkedList.remove(node);
     }
 
     # Updates the linked list based on the replace operation related to the LRU eviction algorithm.
     #
-    # + list - Linked list data structure, which is used to govern the eviction policy
     # + newNode - Node of the linked list, which will be replacing the `oldNode`
     # + oldNode - Node of the linked list, which will be replaced by the `newNode`
-    public isolated function replace(LinkedList list, Node newNode, Node oldNode) {
-        self.linkedList.remove(list, oldNode);
-        self.linkedList.addFirst(list, newNode);
+    public isolated function replace(@tainted Node newNode, Node oldNode) {
+        self.linkedList.remove(oldNode);
+        self.linkedList.addFirst(newNode);
     }
 
     # Updates the linked list based on the clear operation related to the LRU eviction algorithm.
-    #
-    # + list - Linked list data structure, which is used to govern the eviction policy
-    public isolated function clear(LinkedList list) {
-        self.linkedList.clear(list);
+    public isolated function clear() {
+        self.linkedList.clear();
     }
 
     # Updates the linked list based on the evict operation.
-    #
-    # + list - Linked list data structure, which is used to govern the eviction policy
     # + return - The Node, which is evicted from the linked list or `()` if nothing to be evicted
-    public isolated function evict(LinkedList list) returns Node? {
-        return self.linkedList.removeLast(list);
+    public isolated function evict() returns Node? {
+        return self.linkedList.removeLast();
     }
 
 }


### PR DESCRIPTION
## Purpose
We couldn't mark some functions as isolated because this module had a `removeInProgress` module-level global variable. So we removed that variable temporarily and marked those functions as isolated. This PR overcomes this problem and fixes that changes by converting the `LinkedList` record to the object.
