### PR TITLE
Update eviction policy of cache API

### DIFF
--- a/cache-ballerina/cache.bal
+++ b/cache-ballerina/cache.bal
@@ -21,7 +21,6 @@ import ballerina/time;
 # Represents configurations for the `cache:Cache` object.
 #
 # + capacity - Maximum number of entries allowed in the cache
-# + evictionPolicy - The policy, which defines the cache eviction algorithm
 # + evictionFactor - The factor by which the entries will be evicted once the cache is full
 # + defaultMaxAgeInSeconds - The default value in seconds which all the cache entries are valid.
 #                            '-1' means, the entries are valid forever. This will be overwritten by the the
@@ -29,7 +28,6 @@ import ballerina/time;
 # + cleanupIntervalInSeconds - Interval of the timer task, which will clean up the cache
 public type CacheConfig record {|
     int capacity = 100;
-    AbstractEvictionPolicy evictionPolicy = new LruEvictionPolicy();
     float evictionFactor = 0.25;
     int defaultMaxAgeInSeconds = -1;
     int cleanupIntervalInSeconds?;
@@ -70,9 +68,11 @@ public class Cache {
     # Called when a new `cache:Cache` object is created.
     #
     # + cacheConfig - Configurations for the `cache:Cache` object
-    public isolated function init(CacheConfig cacheConfig = {}) {
+    # + evictionPolicy - The policy, which defines the cache eviction algorithm
+    public isolated function init(CacheConfig cacheConfig = {},
+                                  AbstractEvictionPolicy evictionPolicy = new LruEvictionPolicy()) {
         self.maxCapacity = cacheConfig.capacity;
-        self.evictionPolicy = cacheConfig.evictionPolicy;
+        self.evictionPolicy = evictionPolicy;
         self.evictionFactor = cacheConfig.evictionFactor;
         self.defaultMaxAgeInSeconds = cacheConfig.defaultMaxAgeInSeconds;
 

--- a/cache-ballerina/tests/test.bal
+++ b/cache-ballerina/tests/test.bal
@@ -22,12 +22,11 @@ isolated function testCreateCache() {
     LruEvictionPolicy lruEvictionPolicy = new;
     CacheConfig config = {
         capacity: 10,
-        evictionPolicy: lruEvictionPolicy,
         evictionFactor: 0.2,
         defaultMaxAgeInSeconds: 3600,
         cleanupIntervalInSeconds: 5
     };
-    Cache|error cache = trap new(config);
+    Cache|error cache = trap new(config, lruEvictionPolicy);
     if (cache is Cache) {
        test:assertEquals(cache.size(), 0);
     } else {


### PR DESCRIPTION
## Purpose
$subject was done to improve the cache configurations without having object references since behavioural types does not make sense for configurations.

Also, since the auth configurations directly uses `cache:CacheConfig`, this eviction policy object is there for annotations as well. This will be a blocker in future, once the objects references are blocked in annotations. 